### PR TITLE
[1] mmGameMulti::StartXYZ()

### DIFF
--- a/code/midtown/mmgame/gamemulti.cpp
+++ b/code/midtown/mmgame/gamemulti.cpp
@@ -21,6 +21,7 @@ define_dummy_symbol(mmgame_gamemulti);
 #include "gamemulti.h"
 
 #include "mmcar/car.h"
+#include "mmcityinfo/state.h"
 #include "mmnetwork/network.h"
 
 void mmGameMulti::NextRace()
@@ -58,4 +59,49 @@ void mmGameMulti::DeactivateMapNetObject(i32 player)
     icon.Position = 0;
     icon.Place = OPP_ICON_BLANK;
     icon.Enabled = false;
+}
+
+void mmGameMulti::StartXYZ(i32 index, Vector3& out_result, Vector3& start_position, f32 rotation, f32 length)
+{
+    Matrix34 transform_matrix;
+    transform_matrix.Identity();
+    transform_matrix.Rotate(YAXIS, rotation);
+    transform_matrix.m3 = start_position;
+
+    Vector3 position_offset;
+
+    if (length >= 7.0f)
+    {
+        switch (index)
+        {
+            case 0: position_offset.Set(2.75, 0.0, 16.0); break;
+            case 1: position_offset.Set(-2.75, 0.0, 16.0); break;
+            case 2: position_offset.Set(5.5, 0.0, 16.0); break;
+            case 3: position_offset.Set(0.0, 0.0, 16.0); break;
+            case 4: position_offset.Set(2.75, 0.0, 34.0); break;
+            case 5: position_offset.Set(-2.75, 0.0, 34.0); break;
+            case 6: position_offset.Set(0.0, 0.0, 34.0); break;
+            case 7: position_offset.Set(5.5, 0.0, 34.0); break;
+            default: position_offset.Set(0.0, 0.0, 0.0); break;
+        }
+        if (MMSTATE.GameMode == mmGameMode::Blitz && !MMSTATE.EventId)
+            position_offset.z *= -1.0;
+    }
+
+    else
+    {
+        switch (index)
+        {
+            case 0: position_offset.Set(2.25, 0.0, 6.0); break;
+            case 1: position_offset.Set(-2.25, 0.0, 6.0); break;
+            case 2: position_offset.Set(4.5, 0.0, 6.0); break;
+            case 4: position_offset.Set(-4.5, 0.0, 0.0); break;
+            case 5: position_offset.Set(4.5, 0.0, -6.0); break;
+            case 6: position_offset.Set(0.0, 0.0, -6.0); break;
+            case 7: position_offset.Set(-4.5, 0.0, -6.0); break;
+            default: position_offset.Set(0.0, 0.0, 0.0); break;
+        }
+    }
+
+    out_result = position_offset ^ transform_matrix;
 }

--- a/code/midtown/mmgame/gamemulti.h
+++ b/code/midtown/mmgame/gamemulti.h
@@ -183,7 +183,7 @@ protected:
     ARTS_IMPORT void EnableRacers();
 
     // ?StartXYZ@mmGameMulti@@IAEXHAAVVector3@@0MM@Z
-    ARTS_IMPORT void StartXYZ(i32 arg1, Vector3& arg2, Vector3& arg3, f32 arg4, f32 arg5);
+    ARTS_EXPORT void StartXYZ(i32 index, Vector3& out_result, Vector3& start_position, f32 rotation, f32 length);
 
 public:
     f32 ResetRotation;


### PR DESCRIPTION
In an attempt to fix the incorrect starting positions in multiplayer (more specifically, the 2nd till 8th player are stacked on top of each other), first re-implement the position spacing function. We tested this function with a different offset for 2 players, and this worked. However, it seems like this function isn't the root cause of the problem.

![Spawn_Problem_1](https://github.com/0x1F9F1/Open1560/assets/99972691/5ca0e86c-da14-4f06-85a7-2f524fdc09c1)
