### PR TITLE
[1] Tweak StatePack Defaults

### DIFF
--- a/code/midtown/mmcamcs/trackcamcs.h
+++ b/code/midtown/mmcamcs/trackcamcs.h
@@ -49,6 +49,12 @@
 
 #include "carcamcs.h"
 
+#define TRACK_CAM_NEAR 0
+#define TRACK_CAM_BASE 1
+#define TRACK_CAR_FAR 2
+#define TRACK_CAR_XCAM 3
+#define TRACK_CAR_HELICOPTER 4
+
 class TrackCamCS final : public CarCamCS
 {
 public:

--- a/code/midtown/mmcityinfo/state.cpp
+++ b/code/midtown/mmcityinfo/state.cpp
@@ -23,14 +23,16 @@ define_dummy_symbol(mmcityinfo_state);
 #include "data7/args.h"
 #include "midtown.h"
 #include "mmaudio/manager.h"
+#include "mmcamcs/trackcamcs.h"
+#include "mmgame/hudmap.h"
 
 void mmStatePack::SetDefaults()
 {
     CurrentCar = 2; // Hopefully vpbug
-    InputType = mmInputType::Mouse;
+    InputType = mmInputType::Keyboard;
     NetworkStatus = 0;
     NetworkID = 0;
-    ChaseOpponents = 0;
+    ChaseOpponents = false;
     NoUI = false;
     Shutdown = false;
     GameMode = mmGameMode::Cruise;
@@ -40,13 +42,13 @@ void mmStatePack::SetDefaults()
     AmbientDensity = 0.33f;
     PedDensity = 1.0f;
     CopDensity = 1.0f;
-    MaxOpponents = 7.0f;
-    PhysicsRealism = 0.75f;
+    MaxOpponents = 8.0f;
+    PhysicsRealism = 0.25f;
     EnableFF = true;
     UnlockAllRaces = false;
     Weather = mmWeather::Sun;
     TimeOfDay = mmTimeOfDay::Noon;
-    arts_strcpy(CarName, "vpbug");
+    arts_strcpy(CarName, "vppanoz");
     CurrentColor = 0;
     arts_strcpy(NetName, "loaf");
     TimeLimit = 0.0f;
@@ -56,10 +58,10 @@ void mmStatePack::SetDefaults()
     SuperCops = false;
     AmbientCount = 100;
     NumLaps = 0;
-    Difficulty = mmSkillLevel::Amateur;
-    WaveVolume = 1.0f;
+    Difficulty = mmSkillLevel::Professional;
+    WaveVolume = 0.1f;
     AudBalance = 0.0f;
-    CDVolume = 0.5f;
+    CDVolume = 0.1f;
     AudFlags = AudManager::GetHiSampleSizeMask() | AudManager::GetHiResMask() | AudManager::GetStereoOnMask() |
         AudManager::GetCommentaryOnMask() | AudManager::GetCDMusicOnMask() | AudManager::GetSoundFXOnMask();
     AudNumChannels = 32;
@@ -74,15 +76,15 @@ void mmStatePack::SetDefaults()
     CRGoldMass = 0;
 
     arts_strcpy(IntroText, "Loading Open1560");
-    CameraIndex = 0;
-    HudmapMode = 0;
+    CameraIndex = TRACK_CAR_FAR;
+    HudmapMode = HUD_MAP_SMALL;
     WideFov = false;
     DashView = false;
     EnableMirror = true;
     ExternalView = false;
     XcamView = false;
     ShowPositions = true;
-    MapRes = 0;
+    MapRes = 1; // 0 Zoomed out, 1 zoomed in
     DisablePeds = false;
     EnablePaging = false;
     Interlaced = false;
@@ -101,7 +103,7 @@ bool mmStatePack::ParseStateArgs(i32 argc, char** argv)
 
         if (ARG("-noui"))
         {
-            const char* veh_name = "vpbug";
+            const char* veh_name = "vppanoz";
 
             if (asArg* veh = GBArgs['v'])
                 veh_name = veh->sValues[0];

--- a/code/midtown/mmgame/game.cpp
+++ b/code/midtown/mmgame/game.cpp
@@ -481,7 +481,7 @@ void mmGame::UpdateGameInput()
             case IOID_XVIEW: Player->ToggleExternalView(); break;
 
             case IOID_WFOV: {
-                if (Player->HudMap.GetMode() < HUD_MAP_MODE_2)
+                if (Player->HudMap.GetMode() < HUD_MAP_MEDIUM)
                 {
                     Player->ToggleWideFOV();
 

--- a/code/midtown/mmgame/hudmap.h
+++ b/code/midtown/mmgame/hudmap.h
@@ -96,10 +96,10 @@ struct OppIconInfo
 
 check_size(OppIconInfo, 0x24);
 
-#define HUD_MAP_MODE_0 0
-#define HUD_MAP_MODE_1 1
-#define HUD_MAP_MODE_2 2
-#define HUD_MAP_MODE_3 3
+#define HUD_MAP_NONE 0
+#define HUD_MAP_SMALL 1
+#define HUD_MAP_MEDIUM 2
+#define HUD_MAP_LARGE 3
 
 class mmHudMap final : public asNode
 {

--- a/code/midtown/mmgame/interface.cpp
+++ b/code/midtown/mmgame/interface.cpp
@@ -156,3 +156,11 @@ void mmInterface::PlayerResolveCars()
         vehinfo->IsLocked = locked && !AllCars;
     }
 }
+
+void mmInterface::SetStateDefaults()
+{
+    MMSTATE.TimeOfDay = mmTimeOfDay::Noon;
+    MMSTATE.GameMode = mmGameMode::Cruise;
+    MMSTATE.Weather = mmWeather::Sun;
+    MMSTATE.EventId = 0;
+}

--- a/code/midtown/mmgame/interface.h
+++ b/code/midtown/mmgame/interface.h
@@ -421,7 +421,7 @@ private:
     ARTS_IMPORT void SetSessionData(NETSESSION_DESC* arg1);
 
     // ?SetStateDefaults@mmInterface@@AAEXXZ | unused
-    ARTS_IMPORT void SetStateDefaults();
+    ARTS_EXPORT void SetStateDefaults();
 
     // ?SetStateRace@mmInterface@@AAEXH@Z | unused
     ARTS_EXPORT void SetStateRace(i32 arg1);


### PR DESCRIPTION
I changed some settings in the statepack defaults, mostly for convenience when using '-noui- with the Map Editor (especially the audio was quite loud). Alternatively, I could write the changes in the '-noui' argument, but I feel this is cleaner and not a big a problem as the defaults are not used frequently. I also added some constants, assuming XCAM is the "free cam". If you prefer a different constant naming then I can of course change them.