### PR TITLE
 [1] mmBridgeSet::Init

### DIFF
--- a/code/midtown/mmanim/AnimDOF.h
+++ b/code/midtown/mmanim/AnimDOF.h
@@ -101,7 +101,17 @@ public:
     // ?DeclareFields@mmAnimDOF@@SAXXZ
     ARTS_IMPORT static void DeclareFields();
 
-    u8 gap4[0x94];
+    Vector3 field_4;
+    mmUnhitBangerInstance* UnhitBanger;
+    mmDofBangerInstance* DofBanger;
+    Matrix34 field_18;
+    Matrix34 field_48;
+    Vector3 RotationAxis;
+    i32 field_84;
+    i32 field_88;
+    i32 field_8C;
+    i32 Opposite;
+    mmAnimTrigger* Trigger;
 };
 
 check_size(mmAnimDOF, 0x98);

--- a/code/midtown/mmanim/AnimTrigger.h
+++ b/code/midtown/mmanim/AnimTrigger.h
@@ -76,7 +76,15 @@ public:
     // ?Reset@mmAnimTrigger@@QAEXXZ
     ARTS_IMPORT void Reset();
 
-    u8 gap0[0x24];
+    mmInstance* TargetObject;
+    Vector3* TriggerDist2;
+    i32* field_8;
+    i32 ObjectToHit;
+    f32 TimeDelay;
+    f32 Elapsed;
+    f32* TriggerPos;
+    i32 State;
+    b32 Disabled;
 };
 
 check_size(mmAnimTrigger, 0x24);

--- a/code/midtown/mmanim/bridge.cpp
+++ b/code/midtown/mmanim/bridge.cpp
@@ -19,3 +19,92 @@
 define_dummy_symbol(mmanim_bridge);
 
 #include "bridge.h"
+
+#include "mmai/aiMap.h"
+#include "mmai/aiPath.h"
+#include "mmaudio/sound.h"
+#include "mmcity/cullcity.h"
+#include "mmcityinfo/state.h"
+
+i32 mmBridgeSet::Init(char* name, Stream* file)
+{
+    SetName(name);
+
+    for (i32 entry_index = 0; entry_index < NumEntries; ++entry_index)
+    {
+        if (!ReadEntry(file, entry_index))
+        {
+            Errorf("Error reading bridge file");
+            return 0;
+        }
+    }
+
+    if (!MMSTATE.NetworkStatus)
+    {
+        i32 chain_id = AnimDofs[0].DofBanger->ChainId;
+
+        asPortalCell* cell = nullptr;
+
+        if (chain_id >= 0 && chain_id < CullCity()->RenderWeb.MaxCells)
+        {
+            cell = CullCity()->RenderWeb.CellArray[chain_id];
+        }
+
+        if (cell && cell->NumPtlPaths > 0)
+        {
+            PtlPath* base_path = cell->PtlPaths[0];
+
+            if (base_path && base_path->Type == 1)
+            {
+                if (AIMAP.Path(base_path->PathId))
+                {
+                    AIMAP.Path(base_path->PathId)->HasBridge = 1;
+                }
+            }
+
+            if (cell->NumPtlPaths > 1)
+            {
+                PtlPath* oncoming_path = cell->PtlPaths[1];
+
+                if (oncoming_path && AIMAP.Path(oncoming_path->PathId))
+                {
+                    AIMAP.Path(oncoming_path->PathId)->OncomingPath->HasBridge = 1;
+                }
+            }
+        }
+    }
+    return 1;
+}
+
+void mmBridgeSet::InitTrigger()
+{
+    if (Triggered)
+    {
+        State = 3;
+
+        mmAnimTrigger trig;
+        trig.Init(&TriggerPos, &TriggerDist2);
+    }
+}
+
+void mmBridgeSet::SetSoundPtrs(AudSound* sound1, AudSound* sound2)
+{
+    if (Sound1 && Sound1->IsPlaying(0))
+    {
+        Sound1->Stop();
+    }
+
+    if (Sound2 && Sound2->IsPlaying(0))
+    {
+        Sound2->Stop();
+    }
+
+    Sound1 = sound1;
+    Sound2 = sound2;
+}
+
+void mmBridgeSet::UnAssignSounds()
+{
+    SetSoundPtrs(0, 0);
+    MgrIndex = -1;
+}

--- a/code/midtown/mmanim/bridge.h
+++ b/code/midtown/mmanim/bridge.h
@@ -64,6 +64,9 @@
 
 #include "arts7/node.h"
 
+#include "AnimDOF.h"
+#include "AnimTrigger.h"
+
 class AudSound;
 class mmInstance;
 
@@ -89,10 +92,10 @@ public:
     ARTS_IMPORT MetaClass* GetClass() override;
 
     // ?Init@mmBridgeSet@@QAEHPADPAVStream@@@Z
-    ARTS_IMPORT i32 Init(char* arg1, Stream* arg2);
+    ARTS_EXPORT i32 Init(char* name, Stream* file);
 
     // ?InitTrigger@mmBridgeSet@@QAEXXZ
-    ARTS_IMPORT void InitTrigger();
+    ARTS_EXPORT void InitTrigger();
 
     // ?ReadEntry@mmBridgeSet@@QAEHPAVStream@@H@Z
     ARTS_IMPORT i32 ReadEntry(Stream* arg1, i32 arg2);
@@ -101,10 +104,10 @@ public:
     ARTS_IMPORT void Reset() override;
 
     // ?SetSoundPtrs@mmBridgeSet@@QAEXPAVAudSound@@0@Z
-    ARTS_IMPORT void SetSoundPtrs(AudSound* arg1, AudSound* arg2);
+    ARTS_EXPORT void SetSoundPtrs(AudSound* sound1, AudSound* sound2);
 
     // ?UnAssignSounds@mmBridgeSet@@QAEXXZ
-    ARTS_IMPORT void UnAssignSounds();
+    ARTS_EXPORT void UnAssignSounds();
 
     // ?Update@mmBridgeSet@@UAEXXZ
     ARTS_IMPORT void Update() override;
@@ -114,8 +117,6 @@ public:
 
     // ?DeclareFields@mmBridgeSet@@SAXXZ
     ARTS_IMPORT static void DeclareFields();
-
-    offset_field(0x48, f32, TriggerTimeout);
 
 private:
     // ?CalculateAudioPanning@mmBridgeSet@@AAEXXZ
@@ -145,7 +146,33 @@ private:
     // ?s_fCloserMinDistMult@mmBridgeSet@@0MA
     ARTS_IMPORT static f32 s_fCloserMinDistMult;
 
-    u8 gap20[0x418];
+public:
+    mmAnimTrigger Trigger;
+    i32 Triggered;
+    f32 TriggerTimeout;
+    Vector3 TriggerPos;
+    f32 TriggerDist2;
+    i32 NumEntries;
+    mmAnimDOF AnimDofs[6];
+    i32 Switch;
+    i32 State;
+    i32 InitialPos;
+    f32 DownInterval;
+    f32 UpInterval;
+    i32 field_404;
+    i32 field_408;
+    f32 Pan;
+    f32 Volume;
+    f32 field_414;
+    f32 MaxAudioDistSqr;
+    f32 field_41C;
+    f32 field_420;
+    f32 field_424;
+    f32 field_428;
+    AudSound* Sound1;
+    AudSound* Sound2;
+    i16 MgrIndex;
+    u8 Flags;
 };
 
 check_size(mmBridgeSet, 0x438);

--- a/code/midtown/mmcity/portal.h
+++ b/code/midtown/mmcity/portal.h
@@ -84,6 +84,12 @@ struct asPortalView
 
 check_size(asPortalView, 0x48);
 
+struct PtlPath
+{
+    i32 PathId;
+    i32 Type;
+};
+
 struct asPortalCell
 {
     struct PortalLink* Edges;


### PR DESCRIPTION
The original bridge function causes crashes in custom maps when in multiplayer mode. 

This is unfortunate as it forces users to add `-noai`, which then removes the bridges and has other side effects.

I'm not sure why there were additional checks for multiplayer. 
Moreover, I wasn't fully sure how to deal with `PtlPath`.

But for now, the current version compiles and looks to run fine in game.