### PR TITLE
Customize Opponent Color Count

### DIFF
--- a/code/midtown/mmai/aiVehicleOpponent.cpp
+++ b/code/midtown/mmai/aiVehicleOpponent.cpp
@@ -23,13 +23,16 @@ define_dummy_symbol(mmai_aiVehicleOpponent);
 #include "agi/dlptmpl.h"
 #include "agi/getdlp.h"
 #include "agiworld/quality.h"
+#include "data7/str.h"
+#include "mmcityinfo/vehinfo.h"
+#include "mmcityinfo/vehlist.h"
 
 #include "aiData.h"
 #include "aiGoalBackup.h"
 #include "aiGoalFollowWayPts.h"
 #include "aiGoalStop.h"
 
-static mem::cmd_param PARAM_opponent_color_count {"colorcount"};
+static mem::cmd_param PARAM_opp_color_count {"colorcount"};
 
 void aiVehicleOpponent::DrawDamage()
 {}
@@ -40,10 +43,10 @@ void aiVehicleOpponent::Init(i32 opp_id, aiRaceData* race_data, char* race_name)
     if (agiRQ.TextureQuality)
         --agiRQ.TextureQuality;
 
-    i32 paint_job = opp_id % PARAM_opponent_color_count.get_or(4);
-    i32 index = opp_id + 1;
+    OpponentRaceData* opp = static_cast<OpponentRaceData*>(race_data->Opponents.Access(opp_id + 1));
 
-    OpponentRaceData* opp = static_cast<OpponentRaceData*>(race_data->Opponents.Access(index));
+    mmVehInfo* veh_info = VehList()->GetVehicleInfo(opp->Model);
+    i32 paint_job = opp_id % PARAM_opp_color_count.get_or(string(veh_info->Colors).NumSubStrings());
 
     Car.Init(opp->Model, CAR_TYPE_OPPONENT, paint_job);
 
@@ -54,9 +57,7 @@ void aiVehicleOpponent::Init(i32 opp_id, aiRaceData* race_data, char* race_name)
 
     WayPts = arnew aiGoalFollowWayPts(
         opp->PathFile, &RailSet, this, &IsBackup, &IsFinished, &IsStopped, xconst(race_name), opp->MaxThrottle);
-
     BackupGoal = arnew aiGoalBackup(&RailSet, &Car, &IsBackup);
-
     StopGoal = arnew aiGoalStop(&Car, &IsStopped);
 
     IsSemi = !std::strcmp("vpsemi", opp->Model);
@@ -73,5 +74,6 @@ void aiVehicleOpponent::Init(i32 opp_id, aiRaceData* race_data, char* race_name)
         RailSet.BackBumperDist = max.z;
         RailSet.RSideDist = max.x;
     }
+
     AudIndexNumber = -1;
 }

--- a/code/midtown/mmai/aiVehicleOpponent.cpp
+++ b/code/midtown/mmai/aiVehicleOpponent.cpp
@@ -24,7 +24,6 @@ define_dummy_symbol(mmai_aiVehicleOpponent);
 #include "agi/getdlp.h"
 #include "agiworld/quality.h"
 #include "data7/str.h"
-#include "mmcityinfo/vehinfo.h"
 #include "mmcityinfo/vehlist.h"
 
 #include "aiData.h"
@@ -32,7 +31,7 @@ define_dummy_symbol(mmai_aiVehicleOpponent);
 #include "aiGoalFollowWayPts.h"
 #include "aiGoalStop.h"
 
-static mem::cmd_param PARAM_opp_color_count {"colorcount"};
+static mem::cmd_param PARAM_maxoppcolors {"maxoppcolors"};
 
 void aiVehicleOpponent::DrawDamage()
 {}
@@ -46,7 +45,7 @@ void aiVehicleOpponent::Init(i32 opp_id, aiRaceData* race_data, char* race_name)
     OpponentRaceData* opp = static_cast<OpponentRaceData*>(race_data->Opponents.Access(opp_id + 1));
 
     mmVehInfo* veh_info = VehList()->GetVehicleInfo(opp->Model);
-    i32 paint_job = opp_id % PARAM_opp_color_count.get_or(string(veh_info->Colors).NumSubStrings());
+    i32 paint_job = opp_id % PARAM_maxoppcolors.get_or(string(veh_info->Colors).NumSubStrings());
 
     Car.Init(opp->Model, CAR_TYPE_OPPONENT, paint_job);
 

--- a/code/midtown/mmai/aiVehicleOpponent.cpp
+++ b/code/midtown/mmai/aiVehicleOpponent.cpp
@@ -29,6 +29,8 @@ define_dummy_symbol(mmai_aiVehicleOpponent);
 #include "aiGoalFollowWayPts.h"
 #include "aiGoalStop.h"
 
+static mem::cmd_param PARAM_opponent_color_count {"colorcount"};
+
 void aiVehicleOpponent::DrawDamage()
 {}
 
@@ -38,7 +40,7 @@ void aiVehicleOpponent::Init(i32 opp_id, aiRaceData* race_data, char* race_name)
     if (agiRQ.TextureQuality)
         --agiRQ.TextureQuality;
 
-    i32 paint_job = opp_id & 3;
+    i32 paint_job = opp_id % PARAM_opponent_color_count.get_or(4);
     i32 index = opp_id + 1;
 
     OpponentRaceData* opp = static_cast<OpponentRaceData*>(race_data->Opponents.Access(index));

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -40,6 +40,7 @@ For a tutorial on how to use command line arguments, click [here](https://www.bl
 | allrace    | false | Unlocks All Races |
 | maxcops    | 3     | Max cops chasing you at once |
 | nodamage   | false | Disables Damage |
+| maxoppcolors   | auto | Cycles through the opponent car colors based on the number of paintjobs available |
 
 ## Basic
 


### PR DESCRIPTION
With this tweak, users will be able to set how many opponent car colors will be cycled through.

If there are 20 opponents, and 10 available car colors, and the user sets `colorcount -10`, it means that every color will be used twice.