### PR TITLE
Implement aiVehicleOpponent::Update

### DIFF
--- a/code/midtown/mmai/aiVehicleOpponent.cpp
+++ b/code/midtown/mmai/aiVehicleOpponent.cpp
@@ -35,7 +35,7 @@ define_dummy_symbol(mmai_aiVehicleOpponent);
 #include "aiGoalStop.h"
 #include "aiMap.h"
 
-static mem::cmd_param PARAM_detachtrailermph {"detachtrailermph"};
+static mem::cmd_param PARAM_detachopptrailermph {"detachopptrailermph"};
 
 void aiVehicleOpponent::DrawDamage()
 {}
@@ -90,7 +90,6 @@ void aiVehicleOpponent::Update()
     if (IsSemi || Car.Sim.ICS.Matrix.m3.Dist2(AIMAP.PlayerPos()) < (200.0f * 200.0f))
         PHYS.DeclareMover(
             &Car.Model, MOVER_TYPE_PERM, MOVER_FLAG_ACTIVE | MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_COLLIDE_MOVERS);
-
     else
         PHYS.DeclareMover(&Car.Model, MOVER_TYPE_PERM,
             (CullCity()->GetRoomFlags(Car.Model.ChainId) & INST_FLAG_100)
@@ -101,7 +100,7 @@ void aiVehicleOpponent::Update()
         PHYS.DeclareMover(&Car.Trailer->Inst, MOVER_TYPE_PERM, MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_COLLIDE_MOVERS);
 
     if (Car.Sim.HasCollided)
-        if (Car.Sim.SpeedMPH > PARAM_detachtrailermph.get_or(50.0f) && !Car.TrailerJoint->IsBroken())
+        if (Car.Sim.SpeedMPH > PARAM_detachopptrailermph.get_or(50.0f) && !Car.TrailerJoint->IsBroken())
             Car.ReleaseTrailer();
 
     ALLOCATOR.CheckPointer(WayPts.get());

--- a/code/midtown/mmai/aiVehicleOpponent.cpp
+++ b/code/midtown/mmai/aiVehicleOpponent.cpp
@@ -35,7 +35,7 @@ define_dummy_symbol(mmai_aiVehicleOpponent);
 #include "aiGoalStop.h"
 #include "aiMap.h"
 
-static mem::cmd_param PARAM_detach_opponent_trailer_mph {"detach_opponent_trailer_mph"};
+static mem::cmd_param PARAM_detach_opp_trailer_mph {"detach_opp_trailer_mph"};
 
 void aiVehicleOpponent::DrawDamage()
 {}
@@ -89,10 +89,7 @@ void aiVehicleOpponent::Update()
         AddToAiAudMgr();
     }
 
-    Vector3 car_pos_diff = Car.Sim.ICS.Matrix.m3 - AIMAP.PlayerPos();
-    f32 car_dist_sqr = car_pos_diff ^ car_pos_diff;
-
-    if (IsSemi || (car_dist_sqr) < 40000.0f)
+    if (IsSemi || Car.Sim.ICS.Matrix.m3.Dist2(AIMAP.PlayerPos()) < (200.0f * 200.0f))
     {
         PHYS.DeclareMover(
             &Car.Model, MOVER_TYPE_PERM, MOVER_FLAG_ACTIVE | MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_COLLIDE_MOVERS);
@@ -100,7 +97,7 @@ void aiVehicleOpponent::Update()
     else
     {
         PHYS.DeclareMover(&Car.Model, MOVER_TYPE_PERM,
-            (CullCity()->GetRoomFlags(Car.Model.ChainId) & INST_FLAG_100) != 0
+            (CullCity()->GetRoomFlags(Car.Model.ChainId) & INST_FLAG_100)
                 ? MOVER_FLAG_ACTIVE | MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_COLLIDE_MOVERS
                 : MOVER_FLAG_ACTIVE | MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_20);
     }
@@ -111,8 +108,7 @@ void aiVehicleOpponent::Update()
 
         if (Car.Sim.HasCollided)
         {
-            if (Car.Sim.SpeedMPH > PARAM_detach_opponent_trailer_mph.get_or(50.0f) &&
-                (Car.TrailerJoint->JointFlags & JOINT_FLAG_BROKEN) == 0)
+            if (Car.Sim.SpeedMPH > PARAM_detach_opp_trailer_mph.get_or(50.0f) && !Car.TrailerJoint->IsBroken())
             {
                 Car.ReleaseTrailer();
             }

--- a/code/midtown/mmai/aiVehicleOpponent.cpp
+++ b/code/midtown/mmai/aiVehicleOpponent.cpp
@@ -35,7 +35,7 @@ define_dummy_symbol(mmai_aiVehicleOpponent);
 #include "aiGoalStop.h"
 #include "aiMap.h"
 
-static mem::cmd_param PARAM_detach_opp_trailer_mph {"detach_opp_trailer_mph"};
+static mem::cmd_param PARAM_detachtrailermph {"detachtrailermph"};
 
 void aiVehicleOpponent::DrawDamage()
 {}
@@ -85,35 +85,24 @@ void aiVehicleOpponent::Init(i32 opp_id, aiRaceData* race_data, char* race_name)
 void aiVehicleOpponent::Update()
 {
     if (AudIndexNumber == -1)
-    {
         AddToAiAudMgr();
-    }
 
     if (IsSemi || Car.Sim.ICS.Matrix.m3.Dist2(AIMAP.PlayerPos()) < (200.0f * 200.0f))
-    {
         PHYS.DeclareMover(
             &Car.Model, MOVER_TYPE_PERM, MOVER_FLAG_ACTIVE | MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_COLLIDE_MOVERS);
-    }
+
     else
-    {
         PHYS.DeclareMover(&Car.Model, MOVER_TYPE_PERM,
             (CullCity()->GetRoomFlags(Car.Model.ChainId) & INST_FLAG_100)
                 ? MOVER_FLAG_ACTIVE | MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_COLLIDE_MOVERS
                 : MOVER_FLAG_ACTIVE | MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_20);
-    }
 
     if (Car.Model.HasTrailer())
-    {
         PHYS.DeclareMover(&Car.Trailer->Inst, MOVER_TYPE_PERM, MOVER_FLAG_COLLIDE_TERRAIN | MOVER_FLAG_COLLIDE_MOVERS);
 
-        if (Car.Sim.HasCollided)
-        {
-            if (Car.Sim.SpeedMPH > PARAM_detach_opp_trailer_mph.get_or(50.0f) && !Car.TrailerJoint->IsBroken())
-            {
-                Car.ReleaseTrailer();
-            }
-        }
-    }
+    if (Car.Sim.HasCollided)
+        if (Car.Sim.SpeedMPH > PARAM_detachtrailermph.get_or(50.0f) && !Car.TrailerJoint->IsBroken())
+            Car.ReleaseTrailer();
 
     ALLOCATOR.CheckPointer(WayPts.get());
     ALLOCATOR.CheckPointer(BackupGoal.get());

--- a/code/midtown/mmai/aiVehicleOpponent.h
+++ b/code/midtown/mmai/aiVehicleOpponent.h
@@ -122,7 +122,7 @@ public:
     ARTS_IMPORT void UnAssignSounds();
 
     // ?Update@aiVehicleOpponent@@UAEXXZ
-    ARTS_IMPORT void Update() override;
+    ARTS_EXPORT void Update() override;
 
     // ?UpdateAudio@aiVehicleOpponent@@QAEXXZ
     ARTS_IMPORT void UpdateAudio();

--- a/code/midtown/mmphysics/joint3dof.h
+++ b/code/midtown/mmphysics/joint3dof.h
@@ -163,6 +163,11 @@ public:
     // ?DeclareFields@Joint3Dof@@SAXXZ
     ARTS_IMPORT static void DeclareFields();
 
+    b32 IsBroken() const
+    {
+        return (JointFlags & JOINT_FLAG_BROKEN) != 0;
+    }
+
     asInertialCS* ICS1;
     asInertialCS* ICS2;
     Vector3 Offset1;

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,6 +38,7 @@ For a tutorial on how to use command line arguments, click [here](https://www.bl
 | ---------- | ----- | --- |
 | allcars    | false | Unlocks All Cars |
 | allrace    | false | Unlocks All Races |
+| detachopptrailermph | 50 | Speed at which the opponent semi will detach its trailer
 | maxcops    | 3     | Max cops chasing you at once |
 | nodamage   | false | Disables Damage |
 


### PR DESCRIPTION
This function will enable users to keep the opponent's trailer attached (or force it to detach much faster than normal).

For the line:

`Vector3 car_pos_diff = Car.Sim.ICS.Matrix.m3 - AIMAP.PlayerPos();`

This could be an alternative :

`Vector3 car_pos_diff = Car.Sim.ICS.Matrix.m3 - PlayerPos;`

Hopefully all the flags are implemented correctly