### PR TITLE
Always run test build, only update release for 0x1F9F1's master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: build
 
-on:
-  push:
-    branches: [ "master" ]
+on: [push, pull_request]
 
 env:
   PREMAKE_GENERATOR: vs2019
@@ -41,6 +39,7 @@ jobs:
         if-no-files-found: error
 
     - name: Update Release
+      if: github.repository_owner == '0x1F9F1' && github.ref == 'refs/heads/master'
       run: |
         7z a -tzip "artifacts/Open1560.zip" "${{github.workspace}}/build/output/*"
         gh release upload "build" "artifacts/Open1560.zip" --clobber


### PR DESCRIPTION
With this change you'll be sure pull requests actually build before merging them. It also makes it a bit easier to work on the project.

What this PR changes:

- Always run the CI build for pushes, also on other branches than master.
- Only update the release if the master branch on https://github.com/0x1F9F1/Open1560 triggered the CI build.
- Also run the CI build for pull requests. This will make sure that the code would still build after merging.

Hope this helps!