### PR TITLE
Implemented Mouse Scroll Functionality & Dropdown Menu Fix

### DIFF
--- a/code/midtown/game.asm
+++ b/code/midtown/game.asm
@@ -242629,45 +242629,115 @@ loc_4C0E52:
 
 ALIGN 16
 ?GetHit@mmDropDown@@QAEHMM@Z PROC PUBLIC
-    push ebp
-    mov ebp, esp
-    fld dword ptr [ecx+48h]
-    fcomp dword ptr [ebp+8]
-    or edx, -1
-    fnstsw ax
-    test ah, 41h
-    jz loc_4C0F19
-    fld dword ptr [ecx+4Ch]
-    fadd dword ptr [ecx+48h]
-    fcomp dword ptr [ebp+8]
-    fnstsw ax
-    test ah, 1
-    jnz loc_4C0F19
-    fld dword ptr [ecx+54h]
-    fcomp dword ptr [ebp+0Ch]
-    fnstsw ax
-    test ah, 41h
-    jz loc_4C0F19
-    fld dword ptr [ecx+50h]
-    fadd dword ptr [ecx+54h]
-    fcomp dword ptr [ebp+0Ch]
-    fnstsw ax
-    test ah, 1
-    jnz loc_4C0F19
-    fld dword ptr [ebp+0Ch]
-    fsub dword ptr [ecx+54h]
-    fild dword ptr [ecx+58h]
-    fxch st(1)
-    fdiv dword ptr [ecx+50h]
-    fxch st(1)
-    fmulp st(1), st
-    call __ftol
-    mov edx, eax
+    push    ebp
+    mov     ebp, esp
+    push    ebx
+    push    esi
+    push    edi
 
-loc_4C0F19:
-    mov eax, edx
-    pop ebp
-    retn 8
+    mov     edx, 0FFFFFFFFh
+
+    fld     dword ptr [ecx+48h]
+    fcomp   dword ptr [ebp+08h]
+    fnstsw  ax
+    test    ah, 41h
+    jz      loc_return
+
+    fld     dword ptr [ecx+4Ch]
+    fadd    dword ptr [ecx+48h]
+    fcomp   dword ptr [ebp+08h]
+    fnstsw  ax
+    test    ah, 01h
+    jnz     loc_return
+
+    fld     dword ptr [ecx+54h]
+    fcomp   dword ptr [ebp+0Ch]
+    fnstsw  ax
+    test    ah, 41h
+    jz      loc_return
+
+    fld     dword ptr [ecx+50h]
+    fadd    dword ptr [ecx+54h]
+    fcomp   dword ptr [ebp+0Ch]
+    fnstsw  ax
+    test    ah, 01h
+    jnz     loc_return
+
+    fld     dword ptr [ebp+0Ch]
+    fsub    dword ptr [ecx+54h]
+    fdiv    dword ptr [ecx+44h]
+    call    __ftol
+    mov     ebx, eax
+
+    fld     dword ptr [ecx+50h]
+    fdiv    dword ptr [ecx+44h]
+    call    __ftol
+    mov     esi, eax
+    test    esi, esi
+    jg      loc_vis_ok
+    mov     esi, 1
+loc_vis_ok:
+
+    mov     edi, dword ptr [ecx+58h]
+    sub     edi, esi
+    jg      loc_max_ok
+    xor     edi, edi
+loc_max_ok:
+
+    mov     eax, dword ptr [mmDropDown_ScrollCooldown]
+    test    eax, eax
+    jz      loc_cool_ok
+    dec     eax
+    mov     dword ptr [mmDropDown_ScrollCooldown], eax
+    jmp     loc_index_calc
+
+loc_cool_ok:
+
+    mov     eax, ebx
+    cmp     eax, 2                      ; ZONE: bigger number = starts scrolling earlier
+    jg      loc_check_down
+
+    mov     eax, dword ptr [ecx+2Ch]
+    test    eax, eax
+    jle     loc_index_calc
+    dec     eax
+    mov     dword ptr [ecx+2Ch], eax
+    mov     dword ptr [mmDropDown_ScrollCooldown], 3    ; SPEED: bigger number = slower
+    jmp     loc_index_calc
+
+loc_check_down:
+    mov     eax, esi
+    dec     eax
+    sub     eax, 2                      ; ZONE: match the number above
+    mov     edx, ebx
+    cmp     edx, eax
+    jl      loc_index_calc
+
+    mov     eax, dword ptr [ecx+2Ch]
+    cmp     eax, edi
+    jge     loc_index_calc
+    inc     eax
+    mov     dword ptr [ecx+2Ch], eax
+    mov     dword ptr [mmDropDown_ScrollCooldown], 3    ; SPEED: match the number above
+
+loc_index_calc:
+    mov     eax, ebx
+    add     eax, dword ptr [ecx+2Ch]
+
+    cmp     eax, dword ptr [ecx+58h]
+    jl      loc_ok
+    mov     eax, dword ptr [ecx+58h]
+    dec     eax
+loc_ok:
+    mov     edx, eax
+
+loc_return:
+    mov     eax, edx
+    pop     edi
+    pop     esi
+    pop     ebx
+    pop     ebp
+    retn    8
 ?GetHit@mmDropDown@@QAEHMM@Z ENDP
 
 ALIGN 16
@@ -476524,6 +476594,8 @@ stru_630DD0 dd 0FFFFFFFFh
     dd offset loc_616D36
 
 .DATA
+ALIGN 4
+mmDropDown_ScrollCooldown dd 0
 
 ALIGN 4
 ___xc_a dd 0

--- a/code/midtown/mmwidget/dropdown.cpp
+++ b/code/midtown/mmwidget/dropdown.cpp
@@ -25,6 +25,8 @@ define_dummy_symbol(mmwidget_dropdown);
 
 #define MM_DROP_TEXT_EFFECTS (MM_TEXT_VCENTER | MM_TEXT_PADDING | MM_TEXT_REQUIRED)
 
+static constexpr i32 MAX_VISIBLE_ROWS = 15;
+
 mmDropDown::mmDropDown() = default;
 
 mmDropDown::~mmDropDown() = default;
@@ -35,18 +37,23 @@ void mmDropDown::InitString(string values)
     DropIndex = nullptr;
 
     NumValues = values.NumSubStrings();
-    ValueNodes = arnewa mmTextNode[NumValues] {};
-    DropIndex = arnewa u32[NumValues] {};
+    ScrollOffset = 0;
 
-    DropHeight = NumValues * Height;
+    const i32 visibleCount = (NumValues < MAX_VISIBLE_ROWS) ? NumValues : MAX_VISIBLE_ROWS;
+
+    ValueNodes = arnewa mmTextNode[visibleCount] {};
+    DropIndex = arnewa u32[visibleCount] {};
+
+    DropHeight = visibleCount * Height;
     Highlighted = -1;
 
     SetString(std::move(values));
 
-    for (i32 i = 0; i < NumValues; ++i)
+    for (i32 i = 0; i < visibleCount; ++i)
     {
         mmTextNode* node = &ValueNodes[i];
-        string value = ValuesString.SubString(i + 1);
+        const i32 realIndex = ScrollOffset + i;
+        string value = ValuesString.SubString(realIndex + 1);
 
         AddChild(node);
         node->Init(X, Bottom + (i * Height), Width, Height, 1, 0);
@@ -59,22 +66,82 @@ void mmDropDown::InitString(string values)
 
 void mmDropDown::SetHighlight(i32 index)
 {
-    if (Highlighted >= 0 && Highlighted < NumValues)
+    const i32 visibleCount = GetVisibleCount();
+
+    // Clamp index
+    if (index < -1)
+        index = -1;
+    if (index >= NumValues)
+        index = NumValues - 1;
+
+    // Auto scroll if needed
+    if (index >= 0)
     {
-        ValueNodes[Highlighted].SetEffects(0, MM_DROP_TEXT_EFFECTS);
+        if (index < ScrollOffset)
+            ScrollOffset = index;
+        else if (index >= ScrollOffset + visibleCount)
+            ScrollOffset = index - (visibleCount - 1);
     }
 
-    if (index >= 0 && index < NumValues)
+    // Clamp ScrollOffset
+    if (ScrollOffset < 0)
+        ScrollOffset = 0;
+
+    const i32 maxScroll = (NumValues > visibleCount) ? (NumValues - visibleCount) : 0;
+    if (ScrollOffset > maxScroll)
+        ScrollOffset = maxScroll;
+
+    // Refresh visible text to match scroll
+    RefreshVisible();
+
+    // Clear effects for all visible rows (prevents duplicate highlight)
+    for (i32 i = 0; i < visibleCount; ++i)
     {
+        ValueNodes[i].SetEffects(0, MM_DROP_TEXT_EFFECTS);
+    }
+
+    // Apply new highlight if it is visible
+    if (index >= ScrollOffset && index < ScrollOffset + visibleCount)
+    {
+        const i32 vis = index - ScrollOffset;
+
         i32 effects = MM_DROP_TEXT_EFFECTS | MM_TEXT_BORDER;
 
         if (!(DisabledMask & (1 << index)))
             effects |= MM_TEXT_HIGHLIGHT;
 
-        ValueNodes[index].SetEffects(0, effects);
+        ValueNodes[vis].SetEffects(0, effects);
     }
 
     Highlighted = index;
+}
+
+i32 mmDropDown::GetVisibleCount() const
+{
+    return (NumValues < MAX_VISIBLE_ROWS) ? NumValues : MAX_VISIBLE_ROWS;
+}
+
+void mmDropDown::RefreshVisible()
+{
+    const i32 visibleCount = GetVisibleCount();
+
+    // Clamp ScrollOffset
+    if (ScrollOffset < 0)
+        ScrollOffset = 0;
+
+    const i32 maxScroll = (NumValues > visibleCount) ? (NumValues - visibleCount) : 0;
+    if (ScrollOffset > maxScroll)
+        ScrollOffset = maxScroll;
+
+    for (i32 i = 0; i < visibleCount; ++i)
+    {
+        const i32 realIndex = ScrollOffset + i;
+
+        string value = ValuesString.SubString(realIndex + 1);
+
+        // Update existing line instead of adding a new one
+        ValueNodes[i].SetString(DropIndex[i], value.get_loc());
+    }
 }
 
 META_DEFINE_CHILD("mmDropDown", mmDropDown, asNode)

--- a/code/midtown/mmwidget/dropdown.h
+++ b/code/midtown/mmwidget/dropdown.h
@@ -57,6 +57,9 @@ public:
     // ?Update@mmDropDown@@UAEXXZ
     ARTS_IMPORT void Update() override;
 
+    ARTS_EXPORT void RefreshVisible();
+    ARTS_EXPORT i32 GetVisibleCount() const;
+
     VIRTUAL_META_DECLARE;
 
 private:
@@ -66,7 +69,7 @@ private:
     Ptr<mmTextNode[]> ValueNodes;
     Ptr<u32[]> DropIndex;
     i32 Highlighted {-1};
-    i32 field_2C {};
+    i32 ScrollOffset {0};
     i32 Enabled {};
     i32 DisabledMask {};
     asCamera* Camera {};


### PR DESCRIPTION
The Dropdown Menus in the game usually bleed through the screen when items on the list are excessive _(example, when multiple vehicle addons are added to the game, the vehicle list bleeds through the screen)._ 

- This patch **fixes** the bleeding issue by capping the list to a certain height, and also makes the list scrollable to view all the items.

- This commit also adds **mouse "scroll wheel" functionality** to the game.